### PR TITLE
Fix bug in Start ctx handling

### DIFF
--- a/exechelper.go
+++ b/exechelper.go
@@ -37,7 +37,9 @@ func Start(cmdStr string, options ...*Option) <-chan error {
 	// Set the context
 	var ctx context.Context
 	for _, option := range options {
-		ctx = option.Context
+		if option.Context != nil {
+			ctx = option.Context
+		}
 	}
 
 	// Construct the command args


### PR DESCRIPTION
Options that had no context set were overwriting contexts that did.

This both fixes that and tests to prevent regression.